### PR TITLE
feat: double-fold sidebar (category + alphabetical letter)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,18 @@ Alphabet Ukrainien sur une ligne :
 А Б В Г Ґ Д Е Є Ж З И І Ї Й К Л М Н О П Р С Т У Ф Х Ц Ч Ш Щ Ь Ю Я
 
 
+######## Sidebar : double dépliage (catégorie + lettre) ########
+
+La sidebar WordList utilise un système de double dépliage hiérarchique :
+- Niveau 1 : catégories grammaticales (Noms, Adjectifs, Verbes…)
+- Niveau 2 : première lettre ukrainienne à l'intérieur de chaque catégorie
+
+Les mots sont triés selon l'alphabet ukrainien (voir ukrainianSort.js).
+État initial : catégories dépliées, groupes de lettres repliés.
+Contrôles : chevron par catégorie/lettre, bouton ± par catégorie,
+bouton global « Tout déplier / replier » en haut de la sidebar.
+
+
 
 Accents
 
@@ -119,3 +131,17 @@ le format html dans data-info par var=n :
 
 
   à la demande : ⇧⌥F (maj + option + F)
+
+
+
+  ########## NOOJ #################
+
+  besoin de générer les comparatifs et les superlatifs
+  -> absents dans gorox 
+• nécessité aussi de mettre les accents. 
+
+ex: "І цей вибір не випадковий: Rafale — один із найефективніших та найгнучкіших бойових літаків сучасності."
+
+On a accès seulement à 
+ефективний
+гнучкий

--- a/src/lib/components/CategorySection.svelte
+++ b/src/lib/components/CategorySection.svelte
@@ -1,0 +1,99 @@
+<script>
+	import LetterGroup from './LetterGroup.svelte';
+
+	let {
+		catKey,
+		catLabel,
+		isOpen,
+		letterGroups,
+		letterOpenState,
+		wordData,
+		onToggleCategory,
+		onToggleAllLetters,
+		onToggleLetter,
+		onWordClick,
+	} = $props();
+</script>
+
+<div class="category-section">
+	<div class="category-header">
+		<button type="button" class="category-toggle" onclick={onToggleCategory}>
+			<span class="chevron" class:open={isOpen}>▶</span>
+			<h2>{catLabel}</h2>
+		</button>
+		{#if isOpen}
+			<button type="button" class="expand-all-btn" onclick={onToggleAllLetters}
+				title="Tout déplier / replier">
+				±
+			</button>
+		{/if}
+	</div>
+	{#if isOpen}
+		{#each [...letterGroups] as [letter, words]}
+			<LetterGroup
+				{letter}
+				{words}
+				isOpen={letterOpenState[`${catKey}:${letter}`] ?? false}
+				{wordData}
+				onToggle={() => onToggleLetter(letter)}
+				onWordClick={(word) => onWordClick(word, catKey)}
+			/>
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.category-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		border-bottom: 2px solid #ccc;
+		margin-top: 12px;
+		padding-bottom: 4px;
+	}
+
+	.category-toggle {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		background: none;
+		border: none;
+		padding: 0;
+		margin: 0;
+		font: inherit;
+		cursor: pointer;
+		text-align: left;
+		color: inherit;
+	}
+
+	.category-toggle h2 {
+		margin: 0;
+		font-size: 1.1em;
+	}
+
+	.chevron {
+		display: inline-block;
+		font-size: 0.7em;
+		transition: transform 0.15s ease;
+	}
+
+	.chevron.open {
+		transform: rotate(90deg);
+	}
+
+	.expand-all-btn {
+		background: none;
+		border: 1px solid #ccc;
+		border-radius: 3px;
+		padding: 1px 6px;
+		font-size: 0.85em;
+		cursor: pointer;
+		color: #777;
+		line-height: 1;
+	}
+
+	.expand-all-btn:hover {
+		background-color: #e0e0e0;
+		color: #333;
+	}
+</style>

--- a/src/lib/components/LetterGroup.svelte
+++ b/src/lib/components/LetterGroup.svelte
@@ -1,0 +1,93 @@
+<script>
+	import HtmlContent from './HtmlContent.svelte';
+
+	let { letter, words, isOpen, wordData, onToggle, onWordClick } = $props();
+</script>
+
+<div class="letter-group">
+	<button type="button" class="letter-header" onclick={onToggle}>
+		<span class="chevron" class:open={isOpen}>▶</span>
+		<span class="letter">{letter}</span>
+		<span class="count">({words.length})</span>
+	</button>
+	{#if isOpen}
+		<ul class="word-list">
+			{#each words as word}
+				<li class="word-item">
+					<button type="button" class="word-btn" onclick={() => onWordClick(word)}>
+						<HtmlContent html={wordData[word].base_html} disableHover={true} />
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>
+
+<style>
+	.letter-header {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		background: none;
+		border: none;
+		padding: 4px 0 4px 12px;
+		margin: 0;
+		font: inherit;
+		cursor: pointer;
+		width: 100%;
+		text-align: left;
+		color: #555;
+	}
+
+	.letter-header:hover {
+		color: #222;
+	}
+
+	.chevron {
+		display: inline-block;
+		font-size: 0.65em;
+		transition: transform 0.15s ease;
+	}
+
+	.chevron.open {
+		transform: rotate(90deg);
+	}
+
+	.letter {
+		font-weight: 600;
+		font-size: 0.95em;
+	}
+
+	.count {
+		font-size: 0.8em;
+		color: #999;
+	}
+
+	.word-list {
+		list-style-type: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.word-item {
+		padding: 8px 8px 8px 24px;
+		cursor: pointer;
+		border-bottom: 1px solid #eee;
+	}
+
+	.word-item:hover {
+		background-color: #e0e0e0;
+	}
+
+	.word-btn {
+		background: none;
+		border: none;
+		padding: 0;
+		margin: 0;
+		font: inherit;
+		color: inherit;
+		cursor: pointer;
+		text-align: left;
+		width: 100%;
+	}
+</style>

--- a/src/lib/components/WordList.svelte
+++ b/src/lib/components/WordList.svelte
@@ -1,7 +1,8 @@
 <script>
 	import { wordData } from '$lib/stores/dataStore.js';
 	import { selectedWord, selectedCategory } from '$lib/stores/uiStore.js';
-	import HtmlContent from './HtmlContent.svelte';
+	import { groupByFirstLetter } from '$lib/utils/ukrainianSort.js';
+	import CategorySection from './CategorySection.svelte';
 
 	const categories = {
 		nom: 'Noms',
@@ -16,35 +17,104 @@
 		prep: 'Prépositions',
 	};
 
-	function handleWordClick(word, category) {
+	let categoryOpen = $state({});
+	let letterOpen = $state({});
+	let allExpanded = $state(false);
+
+	// Compute grouped data per category
+	let groupedData = $derived(
+		Object.fromEntries(
+			Object.keys(categories)
+				.filter((catKey) => $wordData[catKey] && Object.keys($wordData[catKey]).length > 0)
+				.map((catKey) => [catKey, groupByFirstLetter(Object.keys($wordData[catKey]))])
+		)
+	);
+
+	// Initialize fold state when data loads
+	$effect(() => {
+		const data = $wordData;
+		if (!data || Object.keys(data).length === 0) return;
+
+		const newCatOpen = {};
+		const newLetterOpen = {};
+		for (const catKey of Object.keys(categories)) {
+			if (data[catKey] && Object.keys(data[catKey]).length > 0) {
+				newCatOpen[catKey] = true;
+				const groups = groupByFirstLetter(Object.keys(data[catKey]));
+				for (const letter of groups.keys()) {
+					newLetterOpen[`${catKey}:${letter}`] = false;
+				}
+			}
+		}
+		categoryOpen = newCatOpen;
+		letterOpen = newLetterOpen;
+	});
+
+	function toggleCategory(catKey) {
+		categoryOpen = { ...categoryOpen, [catKey]: !categoryOpen[catKey] };
+	}
+
+	function toggleAllLetters(catKey) {
+		const groups = groupedData[catKey];
+		if (!groups) return;
+		const letters = [...groups.keys()];
+		const allOpen = letters.every((l) => letterOpen[`${catKey}:${l}`]);
+		const updated = { ...letterOpen };
+		for (const l of letters) {
+			updated[`${catKey}:${l}`] = !allOpen;
+		}
+		letterOpen = updated;
+	}
+
+	function toggleLetter(catKey, letter) {
+		letterOpen = { ...letterOpen, [`${catKey}:${letter}`]: !letterOpen[`${catKey}:${letter}`] };
+	}
+
+	function toggleAll() {
+		const expand = !allExpanded;
+		const newCatOpen = {};
+		const newLetterOpen = {};
+		for (const catKey of Object.keys(groupedData)) {
+			newCatOpen[catKey] = expand;
+			for (const letter of groupedData[catKey].keys()) {
+				newLetterOpen[`${catKey}:${letter}`] = expand;
+			}
+		}
+		categoryOpen = newCatOpen;
+		letterOpen = newLetterOpen;
+		allExpanded = expand;
+	}
+
+	function handleWordClick(word, catKey) {
 		selectedWord.set(word);
-		selectedCategory.set(category);
+		selectedCategory.set(catKey);
 	}
 </script>
 
-<ul id="wordList">
+<div id="wordList">
+	<button type="button" class="global-toggle" onclick={toggleAll}>
+		{allExpanded ? '▼ Tout replier' : '▶ Tout déplier'}
+	</button>
+
 	{#each Object.entries(categories) as [catKey, catLabel]}
-		{#if $wordData[catKey] && Object.keys($wordData[catKey]).length > 0}
-			<h2>{catLabel}</h2>
-			<ul class="word-list">
-				{#each Object.entries($wordData[catKey]) as [word, wordInfo]}
-					<li class="word-item">
-						<button type="button" class="word-btn" onclick={() => handleWordClick(word, catKey)}>
-							<HtmlContent html={wordInfo.base_html} disableHover={true} />
-						</button>
-					</li>
-				{/each}
-			</ul>
+		{#if groupedData[catKey]}
+			<CategorySection
+				{catKey}
+				{catLabel}
+				isOpen={categoryOpen[catKey] ?? true}
+				letterGroups={groupedData[catKey]}
+				letterOpenState={letterOpen}
+				wordData={$wordData[catKey]}
+				onToggleCategory={() => toggleCategory(catKey)}
+				onToggleAllLetters={() => toggleAllLetters(catKey)}
+				onToggleLetter={(letter) => toggleLetter(catKey, letter)}
+				onWordClick={handleWordClick}
+			/>
 		{/if}
 	{/each}
-</ul>
+</div>
 
 <style>
-	ul {
-		list-style-type: none;
-		padding: 0;
-	}
-
 	#wordList {
 		flex-grow: 1;
 		overflow-y: auto;
@@ -52,25 +122,23 @@
 		scrollbar-color: #b0b0b0 #e0e0e0;
 	}
 
-	.word-item {
-		padding: 10px;
-		cursor: pointer;
-		border-bottom: 1px solid #ddd;
-	}
-
-	.word-item:hover {
-		background-color: #e0e0e0;
-	}
-
-	.word-btn {
-		background: none;
-		border: none;
-		padding: 0;
-		margin: 0;
-		font: inherit;
-		color: inherit;
-		cursor: pointer;
-		text-align: left;
+	.global-toggle {
+		display: block;
 		width: 100%;
+		background: none;
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		padding: 6px 10px;
+		margin-bottom: 8px;
+		font: inherit;
+		font-size: 0.85em;
+		cursor: pointer;
+		color: #555;
+		text-align: left;
+	}
+
+	.global-toggle:hover {
+		background-color: #e0e0e0;
+		color: #222;
 	}
 </style>

--- a/src/lib/utils/ukrainianSort.js
+++ b/src/lib/utils/ukrainianSort.js
@@ -1,0 +1,74 @@
+/**
+ * Ukrainian alphabet sorting and grouping utilities.
+ */
+
+export const UK_ALPHABET = [
+	'А', 'Б', 'В', 'Г', 'Ґ', 'Д', 'Е', 'Є', 'Ж', 'З',
+	'И', 'І', 'Ї', 'Й', 'К', 'Л', 'М', 'Н', 'О', 'П',
+	'Р', 'С', 'Т', 'У', 'Ф', 'Х', 'Ц', 'Ч', 'Ш', 'Щ',
+	'Ь', 'Ю', 'Я',
+];
+
+const letterRank = new Map();
+for (let i = 0; i < UK_ALPHABET.length; i++) {
+	letterRank.set(UK_ALPHABET[i], i);
+}
+
+function charRank(ch) {
+	const upper = ch.toUpperCase();
+	const rank = letterRank.get(upper);
+	return rank !== undefined ? rank : 1000 + upper.codePointAt(0);
+}
+
+/**
+ * Compare two Ukrainian strings in Ukrainian alphabetical order.
+ * Case-insensitive.
+ */
+export function compareUkrainian(a, b) {
+	const len = Math.min(a.length, b.length);
+	for (let i = 0; i < len; i++) {
+		const ra = charRank(a[i]);
+		const rb = charRank(b[i]);
+		if (ra !== rb) return ra - rb;
+	}
+	return a.length - b.length;
+}
+
+/**
+ * Group word keys by their first Ukrainian letter.
+ * Returns a Map<string, string[]> where keys are uppercase letters
+ * in Ukrainian alphabet order, and values are sorted word arrays.
+ * Letters with no entries are omitted.
+ */
+export function groupByFirstLetter(wordKeys) {
+	const groups = new Map();
+
+	for (const word of wordKeys) {
+		const letter = word[0].toUpperCase();
+		if (!groups.has(letter)) {
+			groups.set(letter, []);
+		}
+		groups.get(letter).push(word);
+	}
+
+	// Sort words within each group
+	for (const words of groups.values()) {
+		words.sort(compareUkrainian);
+	}
+
+	// Rebuild Map in Ukrainian alphabet order
+	const ordered = new Map();
+	for (const letter of UK_ALPHABET) {
+		if (groups.has(letter)) {
+			ordered.set(letter, groups.get(letter));
+		}
+	}
+	// Add any letters not in UK_ALPHABET at the end
+	for (const [letter, words] of groups) {
+		if (!ordered.has(letter)) {
+			ordered.set(letter, words);
+		}
+	}
+
+	return ordered;
+}

--- a/tests/utils/ukrainianSort.test.js
+++ b/tests/utils/ukrainianSort.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  UK_ALPHABET,
+  compareUkrainian,
+  groupByFirstLetter,
+} from "../../src/lib/utils/ukrainianSort.js";
+
+// ─── UK_ALPHABET ────────────────────────────────────────────────────────────
+
+describe("UK_ALPHABET", () => {
+  it("has exactly 33 letters", () => {
+    expect(UK_ALPHABET).toHaveLength(33);
+  });
+
+  it("starts with А and ends with Я", () => {
+    expect(UK_ALPHABET[0]).toBe("А");
+    expect(UK_ALPHABET[32]).toBe("Я");
+  });
+
+  it("contains Ґ after Г", () => {
+    const iГ = UK_ALPHABET.indexOf("Г");
+    const iҐ = UK_ALPHABET.indexOf("Ґ");
+    expect(iҐ).toBe(iГ + 1);
+  });
+
+  it("contains Є after Е", () => {
+    const iЕ = UK_ALPHABET.indexOf("Е");
+    const iЄ = UK_ALPHABET.indexOf("Є");
+    expect(iЄ).toBe(iЕ + 1);
+  });
+
+  it("contains Ї after І", () => {
+    const iІ = UK_ALPHABET.indexOf("І");
+    const iЇ = UK_ALPHABET.indexOf("Ї");
+    expect(iЇ).toBe(iІ + 1);
+  });
+});
+
+// ─── compareUkrainian ───────────────────────────────────────────────────────
+
+describe("compareUkrainian", () => {
+  it("sorts А before Б", () => {
+    expect(compareUkrainian("а", "б")).toBeLessThan(0);
+  });
+
+  it("sorts Ґ between Г and Д", () => {
+    expect(compareUkrainian("ґ", "г")).toBeGreaterThan(0);
+    expect(compareUkrainian("ґ", "д")).toBeLessThan(0);
+  });
+
+  it("sorts Є between Е and Ж", () => {
+    expect(compareUkrainian("є", "е")).toBeGreaterThan(0);
+    expect(compareUkrainian("є", "ж")).toBeLessThan(0);
+  });
+
+  it("sorts Ї between І and Й", () => {
+    expect(compareUkrainian("ї", "і")).toBeGreaterThan(0);
+    expect(compareUkrainian("ї", "й")).toBeLessThan(0);
+  });
+
+  it("sorts Ь between Щ and Ю", () => {
+    expect(compareUkrainian("ь", "щ")).toBeGreaterThan(0);
+    expect(compareUkrainian("ь", "ю")).toBeLessThan(0);
+  });
+
+  it("is case-insensitive", () => {
+    expect(compareUkrainian("А", "а")).toBe(0);
+    expect(compareUkrainian("Ґ", "ґ")).toBe(0);
+  });
+
+  it("sorts multi-character words by subsequent characters", () => {
+    expect(compareUkrainian("банан", "банка")).toBeLessThan(0);
+    expect(compareUkrainian("вода", "водій")).toBeLessThan(0);
+  });
+
+  it("returns 0 for equal words", () => {
+    expect(compareUkrainian("слово", "слово")).toBe(0);
+  });
+
+  it("shorter word comes first when it is a prefix", () => {
+    expect(compareUkrainian("дім", "дімка")).toBeLessThan(0);
+  });
+});
+
+// ─── groupByFirstLetter ────────────────────────────────────────────────────
+
+describe("groupByFirstLetter", () => {
+  it("returns an empty Map for empty input", () => {
+    const result = groupByFirstLetter([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("groups words by their first letter (uppercase)", () => {
+    const result = groupByFirstLetter(["авто", "банан", "ананас"]);
+    expect(result.get("А")).toEqual(["авто", "ананас"]);
+    expect(result.get("Б")).toEqual(["банан"]);
+  });
+
+  it("omits letters with no entries", () => {
+    const result = groupByFirstLetter(["авто", "банан"]);
+    expect(result.has("В")).toBe(false);
+    expect(result.has("Г")).toBe(false);
+  });
+
+  it("returns Map keys in Ukrainian alphabet order", () => {
+    const result = groupByFirstLetter(["яблуко", "авто", "ґанок", "банан"]);
+    const keys = [...result.keys()];
+    expect(keys).toEqual(["А", "Б", "Ґ", "Я"]);
+  });
+
+  it("sorts words within each group in Ukrainian order", () => {
+    const result = groupByFirstLetter(["вода", "вікно", "вітер"]);
+    // і comes after и in Ukrainian: в, и (rank 10), і (rank 11)
+    // вікно, вітер, вода
+    expect(result.get("В")).toEqual(["вікно", "вітер", "вода"]);
+  });
+
+  it("handles words starting with Ґ correctly", () => {
+    const result = groupByFirstLetter(["ґанок", "ґречка"]);
+    expect(result.has("Ґ")).toBe(true);
+    expect(result.get("Ґ")).toEqual(["ґанок", "ґречка"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add two-level collapsible navigation to the WordList sidebar: first by grammar category, then by first Ukrainian letter
- Sort words using Ukrainian alphabet order (А–Я, with correct placement of Ґ, Є, Ї)
- Global and per-category expand/collapse controls with chevron indicators
- Initial state: categories expanded, letter groups collapsed

Closes #10

## Test plan

- [x] 20 new unit tests for `ukrainianSort.js` (sorting + grouping) — all pass
- [x] All 82 tests pass (`npx vitest run`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: verify fold/unfold behavior in browser (`npm run dev`)
- [ ] Manual: verify Ukrainian alphabet order (Ґ after Г, Є after Е, etc.)
- [ ] Manual: verify scrolling works when everything is expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)