### PR TITLE
fix: minor improvements to double-fold sidebar

### DIFF
--- a/src/lib/components/WordList.svelte
+++ b/src/lib/components/WordList.svelte
@@ -19,7 +19,7 @@
 
 	let categoryOpen = $state({});
 	let letterOpen = $state({});
-	let allExpanded = $state(false);
+	let initialized = false;
 
 	// Compute grouped data per category
 	let groupedData = $derived(
@@ -30,17 +30,30 @@
 		)
 	);
 
-	// Initialize fold state when data loads
+	// Derive allExpanded from actual state instead of a manual flag
+	let allExpanded = $derived(
+		Object.keys(groupedData).length > 0 &&
+			Object.keys(groupedData).every((catKey) => {
+				if (!categoryOpen[catKey]) return false;
+				return [...groupedData[catKey].keys()].every(
+					(l) => letterOpen[`${catKey}:${l}`]
+				);
+			})
+	);
+
+	// Initialize fold state when data loads (once)
 	$effect(() => {
 		const data = $wordData;
 		if (!data || Object.keys(data).length === 0) return;
+		if (initialized) return;
+		initialized = true;
 
 		const newCatOpen = {};
 		const newLetterOpen = {};
 		for (const catKey of Object.keys(categories)) {
-			if (data[catKey] && Object.keys(data[catKey]).length > 0) {
+			const groups = groupedData[catKey];
+			if (groups) {
 				newCatOpen[catKey] = true;
-				const groups = groupByFirstLetter(Object.keys(data[catKey]));
 				for (const letter of groups.keys()) {
 					newLetterOpen[`${catKey}:${letter}`] = false;
 				}
@@ -82,7 +95,6 @@
 		}
 		categoryOpen = newCatOpen;
 		letterOpen = newLetterOpen;
-		allExpanded = expand;
 	}
 
 	function handleWordClick(word, catKey) {


### PR DESCRIPTION
## Summary

- **`allExpanded` derived**: replaced manual `$state` flag with `$derived` so the global toggle button ("Tout déplier/replier") stays in sync when individual letter groups are toggled manually
- **`$effect` guard**: added `initialized` flag to prevent resetting user fold state if `$wordData` re-emits
- **`groupedData` reuse**: replaced redundant `groupByFirstLetter()` call in `$effect` with already-computed `groupedData` derived value

Closes #12

## Test plan

- [ ] Toggle global "Tout déplier" → all letters expand, button shows "Tout replier"
- [ ] Manually collapse one letter group → button switches back to "Tout déplier"
- [ ] Category ± button still toggles all letters within category
- [ ] `npm run build` succeeds, `npx vitest run` passes (82 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)