### PR TITLE
feat: sticky category header in sidebar

### DIFF
--- a/src/lib/components/CategorySection.svelte
+++ b/src/lib/components/CategorySection.svelte
@@ -53,7 +53,7 @@
 		position: sticky;
 		top: 0;
 		z-index: 1;
-		background-color: white;
+		background-color: #f0f0f0;
 	}
 
 	.category-toggle {


### PR DESCRIPTION
## Summary

- Make `.category-header` sticky (`position: sticky; top: 0`) so the category name and ± collapse button remain visible while scrolling through expanded letter groups
- Eliminates the need to scroll back up to find the ± button after expanding all letters in a category

Closes #13

## Test plan

- [ ] Expand all letters in a category (e.g. Noms) → scroll down → header stays pinned at top
- [ ] Click ± from sticky header → all letters collapse
- [ ] Click chevron from sticky header → category collapses
- [ ] Scroll past a category → next category header takes over the sticky slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)