### PR TITLE
fix: ± closes letters if any open, opens all only when all closed

### DIFF
--- a/src/lib/components/WordList.svelte
+++ b/src/lib/components/WordList.svelte
@@ -71,10 +71,10 @@
 		const groups = groupedData[catKey];
 		if (!groups) return;
 		const letters = [...groups.keys()];
-		const allOpen = letters.every((l) => letterOpen[`${catKey}:${l}`]);
+		const anyOpen = letters.some((l) => letterOpen[`${catKey}:${l}`]);
 		const updated = { ...letterOpen };
 		for (const l of letters) {
-			updated[`${catKey}:${l}`] = !allOpen;
+			updated[`${catKey}:${l}`] = !anyOpen;
 		}
 		letterOpen = updated;
 	}


### PR DESCRIPTION
## Summary

Replace `letters.every()` with `letters.some()` in `toggleAllLetters` so the ± button behaves intuitively:
- Any letter open → close all
- All letters closed → open all

Closes #16

## Test plan

- [ ] Open a few letters manually, press ± → all close
- [ ] Press ± again → all open
- [ ] Open all letters via ±, press ± → all close

🤖 Generated with [Claude Code](https://claude.com/claude-code)