### PR TITLE
fix(css): sticky header scrollbar overlap & vertical jump

### DIFF
--- a/src/lib/components/CategorySection.svelte
+++ b/src/lib/components/CategorySection.svelte
@@ -43,12 +43,15 @@
 </div>
 
 <style>
+	.category-section {
+		padding-top: 12px;
+	}
+
 	.category-header {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		border-bottom: 2px solid #ccc;
-		margin-top: 12px;
 		padding-bottom: 4px;
 		position: sticky;
 		top: 0;

--- a/src/lib/components/WordList.svelte
+++ b/src/lib/components/WordList.svelte
@@ -132,6 +132,8 @@
 		overflow-y: auto;
 		scrollbar-width: thin;
 		scrollbar-color: #b0b0b0 #e0e0e0;
+		scrollbar-gutter: stable;
+		padding-right: 6px;
 	}
 
 	.global-toggle {


### PR DESCRIPTION
## Summary

- Move `margin-top: 12px` from sticky `.category-header` to `padding-top: 12px` on `.category-section` — eliminates the visual jump when the header sticks
- Add `scrollbar-gutter: stable` and `padding-right: 6px` to `#wordList` — prevents the sticky header from colliding with the scrollbar

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)