### PR TITLE
feat: intègre daisyUI v5 avec thème custom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@sveltejs/kit": "^2.0.0",
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
         "@tailwindcss/vite": "^4.2.2",
+        "daisyui": "^5.5.19",
         "jsdom": "^24.1.3",
         "svelte": "^5.0.0",
         "tailwindcss": "^4.2.2",
@@ -1673,6 +1674,15 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/daisyui": {
+      "version": "5.5.19",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
+      "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tailwindcss/vite": "^4.2.2",
+    "daisyui": "^5.5.19",
     "jsdom": "^24.1.3",
     "svelte": "^5.0.0",
     "tailwindcss": "^4.2.2",

--- a/src/app.css
+++ b/src/app.css
@@ -1,31 +1,47 @@
 @import "tailwindcss";
+@plugin "daisyui";
+@plugin "daisyui/theme" {
+  name: "ukrvocab";
+  default: true;
+  color-scheme: light;
+  --color-primary: oklch(52% 0.18 250);
+  --color-primary-content: oklch(98% 0.01 250);
+  --color-secondary: oklch(55% 0.12 250);
+  --color-secondary-content: oklch(98% 0.01 250);
+  --color-accent: oklch(55% 0.25 25);
+  --color-accent-content: oklch(98% 0.01 25);
+  --color-base-100: oklch(100% 0 0);
+  --color-base-200: oklch(96.5% 0.005 250);
+  --color-base-300: oklch(93% 0.005 250);
+  --color-base-content: oklch(25% 0.02 250);
+  --color-neutral: oklch(40% 0.02 250);
+  --color-neutral-content: oklch(95% 0.01 250);
+  --color-info: oklch(90% 0.04 230);
+  --color-info-content: oklch(40% 0.08 230);
+  --color-warning: oklch(95% 0.04 85);
+  --color-warning-content: oklch(35% 0.05 85);
+  --color-success: oklch(65% 0.2 145);
+  --color-success-content: oklch(98% 0.01 145);
+  --color-error: oklch(60% 0.25 25);
+  --color-error-content: oklch(98% 0.01 25);
+  --radius-box: 0.5rem;
+  --radius-field: 0.25rem;
+  --radius-selector: 1rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}
 
 @theme {
   --font-body: "Times New Roman", serif;
   --font-table: "Times New Roman", serif;
 
+  /* Couleurs spécifiques au domaine (utilisées dans les classes CSS globales) */
   --color-ukr-blue: #2a7ae2;
-  --color-ukr-word: #337ab7;
   --color-accent-red: crimson;
   --color-remarque: brown;
-  --color-sidebar-bg: #f0f0f0;
-  --color-border: #ccc;
-  --color-border-light: #eee;
-  --color-header-bg: #e9e9e9;
-  --color-row-bg: #f5f5f5;
-  --color-hover-bg: #e0e0e0;
-  --color-conj-tense-bg: #d9edf7;
-  --color-conj-tense-text: #31708f;
-  --color-conj-inf-bg: #fcf8e3;
-  --color-conj-number-bg: #f2f2f2;
-  --color-conj-person-bg: #f7f7f9;
-  --color-pinned-border: #6aa0ff;
-  --color-text-muted: #555;
-  --color-text-muted-light: #777;
-  --color-text-muted-lighter: #999;
-  --color-text-dark: #222;
-  --color-text-heading: #333;
-  --color-text-meta: #666;
 
   --z-sticky-letter: 1;
   --z-sticky-toggle: 2;

--- a/src/lib/components/AccentCheckbox.svelte
+++ b/src/lib/components/AccentCheckbox.svelte
@@ -6,7 +6,7 @@
 	}
 </script>
 
-<div class="fixed bottom-5 right-5 bg-white/90 p-2.5 rounded-md shadow-floating z-floating">
-	<input type="checkbox" id="accent-check" checked={$accentEnabled} onchange={toggle} />
-	<label for="accent-check" class="ml-1.5 font-bold">Accents</label>
+<div class="fixed bottom-5 right-5 bg-base-100/90 p-2.5 rounded-md shadow-floating z-floating flex items-center gap-2">
+	<input type="checkbox" id="accent-check" class="toggle toggle-sm toggle-primary" checked={$accentEnabled} onchange={toggle} />
+	<label for="accent-check" class="font-bold cursor-pointer">Accents</label>
 </div>

--- a/src/lib/components/AdjectiveDetails.svelte
+++ b/src/lib/components/AdjectiveDetails.svelte
@@ -8,20 +8,22 @@
 </script>
 
 {#if details.cas}
-	<table class="w-full border-collapse mt-2.5 font-body">
-		<tbody>
+	<table class="table table-zebra mt-2.5 font-body text-[inherit]">
+		<thead>
 			<tr>
-				<td class="border border-border px-3 py-2 text-center font-bold bg-header-bg"></td>
+				<th></th>
 				{#each genders as g}
-					<td class="border border-border px-3 py-2 text-center font-bold bg-header-bg">{labelGender(g)}</td>
+					<th class="text-center">{labelGender(g)}</th>
 				{/each}
 			</tr>
+		</thead>
+		<tbody>
 			{#each Object.entries(details.cas) as [caseKey, forms]}
 				<tr>
-					<td class="border border-border px-3 py-2 font-bold text-left bg-row-bg">{labelCase(caseKey)}</td>
+					<th>{labelCase(caseKey)}</th>
 					{#each genders as gender}
-						<td class="border border-border px-3 py-2 text-center">
-							<span class="text-ukr-word font-bold">{renderCell(forms[gender])}</span>
+						<td class="text-center">
+							<span class="text-secondary font-bold">{renderCell(forms[gender])}</span>
 						</td>
 					{/each}
 				</tr>

--- a/src/lib/components/BaseDetails.svelte
+++ b/src/lib/components/BaseDetails.svelte
@@ -9,4 +9,4 @@
 </script>
 
 <h3>Forme de base</h3>
-<p><span class="text-ukr-word font-bold">{cell}</span></p>
+<p><span class="text-secondary font-bold">{cell}</span></p>

--- a/src/lib/components/CategorySection.svelte
+++ b/src/lib/components/CategorySection.svelte
@@ -16,13 +16,13 @@
 </script>
 
 <div class="pt-3">
-	<div class="flex items-center justify-between border-b-2 border-border pb-1 sticky top-[var(--global-toggle-height,0px)] z-[1] bg-sidebar-bg">
+	<div class="flex items-center justify-between border-b-2 border-base-300 pb-1 sticky top-[var(--global-toggle-height,0px)] z-[1] bg-base-200">
 		<button type="button" class="flex items-center gap-1.5 bg-transparent border-none p-0 m-0 font-[inherit] cursor-pointer text-left text-inherit" onclick={onToggleCategory}>
 			<span class="inline-block text-[0.7em] transition-transform duration-150 ease-in-out" class:rotate-90={isOpen}>▶</span>
 			<h2 class="m-0 text-[1.1em]">{catLabel}</h2>
 		</button>
 		{#if isOpen}
-			<button type="button" class="bg-transparent border border-border rounded-sm px-1.5 py-px text-[0.85em] cursor-pointer text-text-muted-light leading-none hover:bg-hover-bg hover:text-text-heading" onclick={onToggleAllLetters}
+			<button type="button" class="bg-transparent border border-base-300 rounded-sm px-1.5 py-px text-[0.85em] cursor-pointer text-neutral leading-none hover:bg-base-300 hover:text-base-content" onclick={onToggleAllLetters}
 				title="Tout déplier / replier">
 				±
 			</button>

--- a/src/lib/components/ExamplePhrases.svelte
+++ b/src/lib/components/ExamplePhrases.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <h3>Phrases d'exemple:</h3>
-<ul>
+<ul class="text-[0.9em]">
 	{#each Object.entries(phrases) as [phraseKey, _phrase]}
 		{@const pd = $phraseData[phraseKey]}
 		{#if pd}

--- a/src/lib/components/GrammarSidebar.svelte
+++ b/src/lib/components/GrammarSidebar.svelte
@@ -24,10 +24,12 @@
 </script>
 
 {#if visible}
-	<div class="grammar-sidebar fixed right-2.5 top-1/2 -translate-y-1/2 z-grammar-sidebar bg-white border border-border rounded-[10px] w-auto max-w-[380px] max-h-[85vh] overflow-y-auto text-[0.95rem] leading-[1.2] px-2.5 py-2 shadow-grammar {$pinnedElement !== null ? 'border-pinned-border shadow-grammar-pinned' : ''}">
-		<div class="my-1.5 mb-2 px-2 py-1.5 rounded-md bg-black/[.04] text-[15px]">
-			{@html headerHTML}
+	<div class="grammar-sidebar card card-sm fixed right-2.5 top-1/2 -translate-y-1/2 z-grammar-sidebar bg-base-100 w-auto max-w-[380px] max-h-[85vh] overflow-y-auto text-[0.95rem] leading-[1.2] {$pinnedElement !== null ? 'border-primary shadow-grammar-pinned' : 'shadow-grammar'}">
+		<div class="card-body p-3">
+			<div class="px-2 py-1.5 rounded-md bg-base-200 text-[15px]">
+				{@html headerHTML}
+			</div>
+			<GrammarTable data={$grammarTableData} />
 		</div>
-		<GrammarTable data={$grammarTableData} />
 	</div>
 {/if}

--- a/src/lib/components/LetterGroup.svelte
+++ b/src/lib/components/LetterGroup.svelte
@@ -5,15 +5,15 @@
 </script>
 
 <div>
-	<button type="button" class="flex items-center gap-1.5 bg-transparent border-none py-1 pl-3 pr-0 m-0 font-[inherit] cursor-pointer w-full text-left text-text-muted hover:text-text-dark" onclick={onToggle}>
+	<button type="button" class="flex items-center gap-1.5 bg-transparent border-none py-1 pl-3 pr-0 m-0 font-[inherit] cursor-pointer w-full text-left text-neutral hover:text-base-content" onclick={onToggle}>
 		<span class="inline-block text-[0.65em] transition-transform duration-150 ease-in-out" class:rotate-90={isOpen}>▶</span>
 		<span class="font-semibold text-[0.95em]">{letter}</span>
-		<span class="text-[0.8em] text-text-muted-lighter">({words.length})</span>
+		<span class="text-[0.8em] opacity-50">({words.length})</span>
 	</button>
 	{#if isOpen}
 		<ul class="list-none p-0 m-0">
 			{#each words as word}
-				<li class="py-2 px-2 pl-6 cursor-pointer border-b border-border-light hover:bg-hover-bg">
+				<li class="py-2 px-2 pl-6 cursor-pointer border-b border-base-200 hover:bg-base-200">
 					<button type="button" class="bg-transparent border-none p-0 m-0 font-[inherit] text-inherit cursor-pointer text-left w-full" onclick={() => onWordClick(word)}>
 						<HtmlContent html={wordData[word].base_html} disableHover={true} />
 					</button>

--- a/src/lib/components/NounDetails.svelte
+++ b/src/lib/components/NounDetails.svelte
@@ -6,18 +6,20 @@
 </script>
 
 {#if details.cas}
-	<table class="w-full border-collapse mt-2.5 font-body">
-		<tbody>
+	<table class="table table-zebra mt-2.5 font-body text-[inherit]">
+		<thead>
 			<tr>
-				<td class="border border-border px-3 py-2 text-center font-bold bg-header-bg"></td>
-				<td class="border border-border px-3 py-2 text-center font-bold bg-header-bg">sg.</td>
-				<td class="border border-border px-3 py-2 text-center font-bold bg-header-bg">pl.</td>
+				<th></th>
+				<th class="text-center">sg.</th>
+				<th class="text-center">pl.</th>
 			</tr>
+		</thead>
+		<tbody>
 			{#each Object.entries(details.cas) as [caseKey, forms]}
 				<tr>
-					<td class="border border-border px-3 py-2 font-bold text-left bg-row-bg">{labelCase(caseKey)}</td>
-					<td class="border border-border px-3 py-2 text-center"><span class="text-ukr-word font-bold">{renderCell(forms.s)}</span></td>
-					<td class="border border-border px-3 py-2 text-center"><span class="text-ukr-word font-bold">{renderCell(forms.pl)}</span></td>
+					<th>{labelCase(caseKey)}</th>
+					<td class="text-center"><span class="text-secondary font-bold">{renderCell(forms.s)}</span></td>
+					<td class="text-center"><span class="text-secondary font-bold">{renderCell(forms.pl)}</span></td>
 				</tr>
 			{/each}
 		</tbody>

--- a/src/lib/components/PhraseList.svelte
+++ b/src/lib/components/PhraseList.svelte
@@ -10,19 +10,19 @@
 	);
 </script>
 
-<div class="fixed top-5 right-5 bg-white/90 p-2.5 rounded-md shadow-floating z-floating">
-	<input type="text" bind:value={searchQuery} placeholder="Rechercher..." />
+<div class="fixed top-5 right-5 bg-base-100/90 p-2.5 rounded-md shadow-floating z-floating">
+	<input type="text" class="input input-bordered input-sm" bind:value={searchQuery} placeholder="Rechercher..." />
 </div>
 
 <ul class="list-none p-0">
 	{#each Object.entries(filteredPhrases) as [phraseKey, phraseInfo]}
-		<li class="mb-4">
+		<li class="mb-4 p-3 rounded-lg hover:bg-base-200 transition-colors">
 			<div class="font-bold">
 				<HtmlContent html={phraseInfo.phrase_html} />
 			</div>
-			<div class="italic text-text-muted">{phraseInfo.traduction}</div>
+			<div class="italic text-neutral mt-1">{phraseInfo.traduction}</div>
 			{#if phraseInfo.ref}
-				<div class="references">Références : {JSON.stringify(phraseInfo.ref)}</div>
+				<div class="references text-sm opacity-60 mt-1">Références : {JSON.stringify(phraseInfo.ref)}</div>
 			{/if}
 		</li>
 	{/each}

--- a/src/lib/components/VerbDetails.svelte
+++ b/src/lib/components/VerbDetails.svelte
@@ -9,7 +9,7 @@
 	function renderCell(entry) {
 		const pairs = toPairs(entry);
 		if (!pairs.length) return '';
-		return pairs.filter(([t]) => t).map(([t, p]) => `<span class="text-ukr-word font-bold">${addAccent(t, p)}</span>`).join(', ');
+		return pairs.filter(([t]) => t).map(([t, p]) => `<span class="text-secondary font-bold">${addAccent(t, p)}</span>`).join(', ');
 	}
 
 	const infPair = $derived(firstPair(details.inf));
@@ -26,30 +26,30 @@
 		return couplInf ? renderCell(couplInf) : coupl;
 	});
 
-	const cellBase = 'border border-border px-3 py-2 text-center max-md:px-2 max-md:py-1.5';
+	const cellBase = 'px-3 py-2 text-center max-md:px-2 max-md:py-1.5';
 </script>
 
 {#if details.conj}
-	<table class="w-full border-collapse mt-5 font-body">
+	<table class="table mt-5 font-body text-[inherit]">
 		<tbody>
 			<!-- Infinitif -->
-			<tr class="bg-conj-inf-bg">
+			<tr class="bg-warning">
 				<td class="{cellBase}">Infinitif</td>
 				<td colspan="2" class="{cellBase}">
-					<span class="text-ukr-word font-bold">{infDisplay}</span>
+					<span class="text-secondary font-bold">{infDisplay}</span>
 				</td>
 			</tr>
 
 			{#each tenses as tenseKey}
 				{#if details.conj[tenseKey]}
-					<tr class="bg-conj-tense-bg text-conj-tense-text text-[1.1em]">
+					<tr class="bg-info text-info-content text-[1.1em]">
 						<td colspan="3" class="{cellBase} font-bold">{labelTenseLabel(tenseKey)}</td>
 					</tr>
 
 					{#if tenseKey === 'pass'}
 						{#each Object.entries(details.conj.pass) as [gKey, forms]}
 							<tr>
-								<td class="{cellBase} text-left font-bold bg-row-bg">{labelPerson(gKey)}</td>
+								<td class="{cellBase} text-left font-bold bg-base-200">{labelPerson(gKey)}</td>
 								<td class="{cellBase}">{@html renderCell(forms.s)}</td>
 								{#if gKey === 'm'}
 									<td rowspan="3" class="{cellBase}">{@html renderCell(forms.pl)}</td>
@@ -57,14 +57,14 @@
 							</tr>
 						{/each}
 					{:else}
-						<tr class="bg-conj-person-bg font-bold">
+						<tr class="bg-base-200 font-bold">
 							<td class="{cellBase}">&nbsp;</td>
-							<td class="{cellBase} bg-conj-number-bg">sg.</td>
-							<td class="{cellBase} bg-conj-number-bg">pl.</td>
+							<td class="{cellBase} bg-base-300">sg.</td>
+							<td class="{cellBase} bg-base-300">pl.</td>
 						</tr>
 						{#each Object.entries(details.conj[tenseKey]) as [pKey, forms]}
 							<tr>
-								<td class="{cellBase} text-left font-bold bg-row-bg">{@html labelPerson(pKey)}</td>
+								<td class="{cellBase} text-left font-bold bg-base-200">{@html labelPerson(pKey)}</td>
 								<td class="{cellBase}">{@html renderCell(forms.s)}</td>
 								<td class="{cellBase}">{@html renderCell(forms.pl)}</td>
 							</tr>
@@ -75,7 +75,7 @@
 
 			<!-- Forme impersonnelle -->
 			{#if impersData}
-				<tr class="bg-conj-tense-bg text-conj-tense-text text-[1.1em]">
+				<tr class="bg-info text-info-content text-[1.1em]">
 					<td colspan="3" class="{cellBase} font-bold">Forme impersonnelle</td>
 				</tr>
 				<tr>

--- a/src/lib/components/WordDetails.svelte
+++ b/src/lib/components/WordDetails.svelte
@@ -46,7 +46,7 @@
 
 <div class="mx-[10%] p-5">
 	{#if details}
-		<h2>{displayWord} <span class="text-[0.65em] font-normal text-text-meta align-middle">: {displayMeta}</span></h2>
+		<h2>{displayWord} <span class="badge badge-ghost text-[0.65em] font-normal align-middle ml-2">{displayMeta}</span></h2>
 
 		{#if $selectedCategory === 'nom'}
 			<NounDetails {details} />

--- a/src/lib/components/WordList.svelte
+++ b/src/lib/components/WordList.svelte
@@ -97,7 +97,7 @@
 </script>
 
 <div id="wordList" class="grow overflow-y-auto pr-1.5" style="--global-toggle-height: 38px; scrollbar-width: thin; scrollbar-color: #b0b0b0 #e0e0e0; scrollbar-gutter: stable;">
-	<button type="button" class="block w-full bg-sidebar-bg border border-border rounded px-2.5 py-1.5 mb-0 font-[inherit] text-[0.85em] cursor-pointer text-text-muted text-left sticky top-0 z-[2] hover:bg-hover-bg hover:text-text-dark" onclick={toggleAll}>
+	<button type="button" class="block w-full bg-base-200 border border-base-300 rounded px-2.5 py-1.5 mb-0 font-[inherit] text-[0.85em] cursor-pointer text-neutral text-left sticky top-0 z-[2] hover:bg-base-300 hover:text-base-content" onclick={toggleAll}>
 		{anyExpanded ? '▼ Tout replier' : '▶ Tout déplier'}
 	</button>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,10 +8,10 @@
 </svelte:head>
 
 <div class="flex w-full h-full max-md:flex-col">
-	<div class="w-1/4 bg-sidebar-bg p-5 shadow-sidebar h-screen flex flex-col max-md:w-full max-md:h-auto">
+	<div class="w-1/4 bg-base-200 p-5 shadow-sidebar h-screen flex flex-col max-md:w-full max-md:h-auto">
 		<WordList />
 	</div>
-	<div class="w-3/4 p-5 max-md:w-full">
+	<div class="w-3/4 p-5 max-md:w-full bg-base-100">
 		<WordDetails />
 	</div>
 </div>


### PR DESCRIPTION
## Summary

- Ajout de daisyUI v5 comme plugin Tailwind CSS v4
- Thème custom `ukrvocab` en oklch mappant les couleurs existantes
- Migration de 12 tokens custom vers les tokens daisyUI standard (base-200, base-300, secondary, info, warning, neutral, primary)
- Composants daisyUI utilisés : `table table-zebra`, `card`, `toggle`, `input input-bordered`, `badge`
- Nettoyage des tokens obsolètes dans `@theme`

Addresses #26

## Test plan

- [x] 107 tests passent
- [x] Build statique OK
- [ ] Vérifier visuellement tables, sidebar, grammar sidebar, toggle, recherche phrases

🤖 Generated with [Claude Code](https://claude.com/claude-code)