### PR TITLE
feat: table design system et finition grammar sidebar

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -89,26 +89,141 @@ body {
   color: var(--color-remarque);
 }
 
-/* Grammar sidebar — table descendant selectors for @html content */
+/* ── Table design system ───────────────────────────────────────────── */
+
+/* Base editorial table — used alongside daisyUI `table` on main tables.
+   Provides horizontal rules instead of zebra stripes. */
+.gram-table {
+  border-collapse: collapse;
+}
+
+.gram-table tbody tr {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.gram-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+/* Column headers (sg., pl., m., f., etc.) */
+.gram-table thead th {
+  font-weight: 600;
+  font-style: italic;
+  color: var(--color-neutral);
+  border-bottom: 2px solid var(--color-base-300);
+}
+
+/* Row labels (case names in tbody th) */
+.gram-table tbody th {
+  font-weight: 600;
+  font-style: italic;
+  color: var(--color-neutral);
+  text-align: left;
+  white-space: nowrap;
+}
+
+/* Section divider row — tense headers, infinitif row */
+.gram-section td,
+.gram-section th {
+  background: var(--color-surface-raised);
+  border-top: 2px solid var(--color-base-300);
+  font-weight: 700;
+}
+
+/* No top border on the very first section (top of table) */
+.gram-table tbody tr:first-child.gram-section td {
+  border-top: none;
+}
+
+/* Section rows don't need the regular bottom border */
+.gram-table tbody tr.gram-section {
+  border-bottom: none;
+}
+
+/* Label cell — person/gender in first column.
+   No text-align: left is the default; omitting allows text-center override. */
+.gram-label {
+  font-style: italic;
+  font-weight: 600;
+  color: var(--color-neutral);
+  white-space: nowrap;
+}
+
+/* Footer note below a table (couple aspectuel, etc.) */
+.gram-note {
+  text-align: right;
+  font-style: italic;
+  margin-top: 0.375rem;
+  font-size: var(--text-sm);
+  color: var(--color-neutral);
+}
+
+/* Mobile overflow wrapper */
+.gram-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Grammar sidebar header — replaces inline styles */
+.gram-header-word {
+  font-weight: 600;
+}
+
+.gram-header-meta {
+  opacity: 0.8;
+}
+
+/* ── Grammar sidebar — descendant selectors for @html content ───── */
+
 .grammar-sidebar table {
-  width: auto;
-  border-collapse: separate;
-  border-spacing: 0;
+  width: 100%;
+  border-collapse: collapse;
 }
 
 .grammar-sidebar th,
 .grammar-sidebar td {
-  padding: 2px 6px;
+  padding: 4px 8px;
   vertical-align: top;
 }
 
+/* Section headers (case names, tense names) */
 .grammar-sidebar th {
   text-align: left;
   font-style: italic;
   font-weight: 700;
   background: var(--color-surface-raised);
+  border-top: 1.5px solid var(--color-base-300);
   position: sticky;
   top: 0;
+}
+
+/* No top border on the very first section header */
+.grammar-sidebar tr:first-child > th {
+  border-top: none;
+}
+
+/* Row borders between data rows */
+.grammar-sidebar tr + tr > td {
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+/* Label column (sg., pl., m., f., 1p., etc.) */
+.grammar-sidebar td:first-child {
+  color: var(--color-neutral);
+  white-space: nowrap;
+}
+
+/* Active / current form — the <strong> wrapping the hovered form */
+.grammar-sidebar strong {
+  color: var(--color-ukr-blue);
+  font-weight: 700;
+}
+
+/* Footer note inside sidebar (couple aspectuel) */
+.grammar-sidebar .gram-note {
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 0.25rem;
+  margin-top: 0.25rem;
 }
 
 /* Hover bubble — kept for HtmlContent.svelte (createElement) */

--- a/src/lib/components/AdjectiveDetails.svelte
+++ b/src/lib/components/AdjectiveDetails.svelte
@@ -8,26 +8,28 @@
 </script>
 
 {#if details.cas}
-	<table class="table table-zebra mt-2.5 font-body">
-		<thead>
-			<tr>
-				<th></th>
-				{#each genders as g}
-					<th class="text-center">{labelGender(g)}</th>
-				{/each}
-			</tr>
-		</thead>
-		<tbody>
-			{#each Object.entries(details.cas) as [caseKey, forms]}
+	<div class="gram-table-wrap mt-2.5">
+		<table class="table gram-table font-body">
+			<thead>
 				<tr>
-					<th>{labelCase(caseKey)}</th>
-					{#each genders as gender}
-						<td class="text-center">
-							<span class="text-secondary font-bold">{renderCell(forms[gender])}</span>
-						</td>
+					<th></th>
+					{#each genders as g}
+						<th class="text-center">{labelGender(g)}</th>
 					{/each}
 				</tr>
-			{/each}
-		</tbody>
-	</table>
+			</thead>
+			<tbody>
+				{#each Object.entries(details.cas) as [caseKey, forms]}
+					<tr>
+						<th>{labelCase(caseKey)}</th>
+						{#each genders as gender}
+							<td class="text-center">
+								<span class="text-secondary font-bold">{renderCell(forms[gender])}</span>
+							</td>
+						{/each}
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
 {/if}

--- a/src/lib/components/GrammarSidebar.svelte
+++ b/src/lib/components/GrammarSidebar.svelte
@@ -19,14 +19,14 @@
 			if (g) meta += `, ${g}`;
 		}
 		const head = getPrincipalForm(wordData, word, category);
-		return `<strong style="font-weight:600;">${head}</strong> <span style="opacity:.8;"> — ${meta}</span>`;
+		return `<span class="gram-header-word">${head}</span> <span class="gram-header-meta"> — ${meta}</span>`;
 	});
 </script>
 
 {#if visible}
-	<div class="grammar-sidebar card card-sm fixed right-2.5 top-1/2 -translate-y-1/2 z-grammar-sidebar bg-base-100 w-auto max-w-sm max-h-[85vh] overflow-y-auto text-base leading-[1.2] {$pinnedElement !== null ? 'border-primary shadow-grammar-pinned' : 'shadow-grammar'}">
+	<div class="grammar-sidebar card card-sm fixed right-2.5 top-1/2 -translate-y-1/2 z-grammar-sidebar bg-base-100 w-auto max-w-sm max-h-[85vh] overflow-y-auto text-sm leading-snug {$pinnedElement !== null ? 'border-primary shadow-grammar-pinned' : 'shadow-grammar'}">
 		<div class="card-body p-3">
-			<div class="px-2 py-1.5 rounded-md bg-base-200 text-sm">
+			<div class="px-2 py-1.5 mb-1 border-b border-base-300 text-sm">
 				{@html headerHTML}
 			</div>
 			<GrammarTable data={$grammarTableData} />

--- a/src/lib/components/GrammarTable.svelte
+++ b/src/lib/components/GrammarTable.svelte
@@ -136,7 +136,7 @@
 		if (coupl) {
 			const couplInf = wd?.verb?.[coupl]?.inf;
 			const couplDisplay = couplInf ? renderCell(couplInf) : coupl;
-			html += `<div style="text-align:right; font-style:italic; margin-top:6px;">Couple aspectuel : ${couplDisplay}</div>`;
+			html += `<div class="gram-note">Couple aspectuel : ${couplDisplay}</div>`;
 		}
 
 		return html;

--- a/src/lib/components/NounDetails.svelte
+++ b/src/lib/components/NounDetails.svelte
@@ -6,22 +6,24 @@
 </script>
 
 {#if details.cas}
-	<table class="table table-zebra mt-2.5 font-body">
-		<thead>
-			<tr>
-				<th></th>
-				<th class="text-center">sg.</th>
-				<th class="text-center">pl.</th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each Object.entries(details.cas) as [caseKey, forms]}
+	<div class="gram-table-wrap mt-2.5">
+		<table class="table gram-table font-body">
+			<thead>
 				<tr>
-					<th>{labelCase(caseKey)}</th>
-					<td class="text-center"><span class="text-secondary font-bold">{renderCell(forms.s)}</span></td>
-					<td class="text-center"><span class="text-secondary font-bold">{renderCell(forms.pl)}</span></td>
+					<th></th>
+					<th class="text-center">sg.</th>
+					<th class="text-center">pl.</th>
 				</tr>
-			{/each}
-		</tbody>
-	</table>
+			</thead>
+			<tbody>
+				{#each Object.entries(details.cas) as [caseKey, forms]}
+					<tr>
+						<th>{labelCase(caseKey)}</th>
+						<td class="text-center"><span class="text-secondary font-bold">{renderCell(forms.s)}</span></td>
+						<td class="text-center"><span class="text-secondary font-bold">{renderCell(forms.pl)}</span></td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
 {/if}

--- a/src/lib/components/VerbDetails.svelte
+++ b/src/lib/components/VerbDetails.svelte
@@ -26,71 +26,68 @@
 		return couplInf ? renderCell(couplInf) : coupl;
 	});
 
-	const cellBase = 'px-3 py-2 text-center max-md:px-2 max-md:py-1.5';
+	const cp = 'px-3 py-2 max-md:px-2 max-md:py-1.5';
 </script>
 
 {#if details.conj}
-	<table class="table mt-5 font-body">
-		<tbody>
-			<!-- Infinitif -->
-			<tr class="bg-warning">
-				<td class="{cellBase}">Infinitif</td>
-				<td colspan="2" class="{cellBase}">
-					<span class="text-secondary font-bold">{infDisplay}</span>
-				</td>
-			</tr>
-
-			{#each tenses as tenseKey}
-				{#if details.conj[tenseKey]}
-					<tr class="bg-info text-info-content text-lg">
-						<td colspan="3" class="{cellBase} font-bold">{labelTenseLabel(tenseKey)}</td>
-					</tr>
-
-					{#if tenseKey === 'pass'}
-						{#each Object.entries(details.conj.pass) as [gKey, forms]}
-							<tr>
-								<td class="{cellBase} text-left font-bold bg-base-200">{labelPerson(gKey)}</td>
-								<td class="{cellBase}">{@html renderCell(forms.s)}</td>
-								{#if gKey === 'm'}
-									<td rowspan="3" class="{cellBase}">{@html renderCell(forms.pl)}</td>
-								{/if}
-							</tr>
-						{/each}
-					{:else}
-						<tr class="bg-base-200 font-bold">
-							<td class="{cellBase}">&nbsp;</td>
-							<td class="{cellBase} bg-base-300">sg.</td>
-							<td class="{cellBase} bg-base-300">pl.</td>
-						</tr>
-						{#each Object.entries(details.conj[tenseKey]) as [pKey, forms]}
-							<tr>
-								<td class="{cellBase} text-left font-bold bg-base-200">{@html labelPerson(pKey)}</td>
-								<td class="{cellBase}">{@html renderCell(forms.s)}</td>
-								<td class="{cellBase}">{@html renderCell(forms.pl)}</td>
-							</tr>
-						{/each}
-					{/if}
-				{/if}
-			{/each}
-
-			<!-- Forme impersonnelle -->
-			{#if impersData}
-				<tr class="bg-info text-info-content text-lg">
-					<td colspan="3" class="{cellBase} font-bold">Forme impersonnelle</td>
-				</tr>
-				<tr>
-					<td colspan="3" class="{cellBase}">{@html renderCell(impersData)}</td>
-				</tr>
-			{/if}
-
-			<!-- Couple aspectuel -->
-			{#if coupl}
-				<tr>
-					<td colspan="3" class="{cellBase} text-right italic">
-						Couple aspectuel : {@html couplDisplay}
+	<div class="gram-table-wrap mt-5">
+		<table class="table gram-table font-body">
+			<tbody>
+				<!-- Infinitif -->
+				<tr class="gram-section">
+					<td class="{cp} gram-label">Infinitif</td>
+					<td colspan="2" class="{cp} text-center">
+						<span class="text-secondary font-bold">{infDisplay}</span>
 					</td>
 				</tr>
-			{/if}
-		</tbody>
-	</table>
+
+				{#each tenses as tenseKey}
+					{#if details.conj[tenseKey]}
+						<tr class="gram-section">
+							<td colspan="3" class="{cp} text-center text-lg">{labelTenseLabel(tenseKey)}</td>
+						</tr>
+
+						{#if tenseKey === 'pass'}
+							{#each Object.entries(details.conj.pass) as [gKey, forms]}
+								<tr>
+									<td class="{cp} gram-label">{labelPerson(gKey)}</td>
+									<td class="{cp} text-center">{@html renderCell(forms.s)}</td>
+									{#if gKey === 'm'}
+										<td rowspan="3" class="{cp} text-center">{@html renderCell(forms.pl)}</td>
+									{/if}
+								</tr>
+							{/each}
+						{:else}
+							<tr>
+								<td class="{cp}">&nbsp;</td>
+								<td class="{cp} gram-label text-center">sg.</td>
+								<td class="{cp} gram-label text-center">pl.</td>
+							</tr>
+							{#each Object.entries(details.conj[tenseKey]) as [pKey, forms]}
+								<tr>
+									<td class="{cp} gram-label">{@html labelPerson(pKey)}</td>
+									<td class="{cp} text-center">{@html renderCell(forms.s)}</td>
+									<td class="{cp} text-center">{@html renderCell(forms.pl)}</td>
+								</tr>
+							{/each}
+						{/if}
+					{/if}
+				{/each}
+
+				<!-- Forme impersonnelle -->
+				{#if impersData}
+					<tr class="gram-section">
+						<td colspan="3" class="{cp} text-center text-lg">Forme impersonnelle</td>
+					</tr>
+					<tr>
+						<td colspan="3" class="{cp} text-center">{@html renderCell(impersData)}</td>
+					</tr>
+				{/if}
+			</tbody>
+		</table>
+	</div>
+
+	{#if coupl}
+		<p class="gram-note">Couple aspectuel : {@html couplDisplay}</p>
+	{/if}
 {/if}


### PR DESCRIPTION
## Summary

- Crée un mini design system de tables CSS (`.gram-table`, `.gram-section`, `.gram-label`, `.gram-note`, `.gram-table-wrap`) pour un rendu sobre et académique
- Applique ce système à `NounDetails`, `AdjectiveDetails` et `VerbDetails` — remplace zebra-striping par filets horizontaux, élimine le patchwork de couleurs
- Enrichit les règles `.grammar-sidebar` : tables à 100% largeur, bordures inter-lignes, headers sticky, forme active en bleu, footer couple aspectuel
- Supprime tous les styles inline restants (GrammarSidebar header, GrammarTable couple aspectuel)

Closes #29

## Test plan

- [x] `npm run build` — build statique OK
- [x] `npm run test` — 107 tests passent (8 fichiers)
- [ ] Vérification visuelle : tables noms/adj/verbes avec filets horizontaux
- [ ] Grammar sidebar : headers sticky, forme active en bleu
- [ ] Responsive < 768px : tables scrollables horizontalement

🤖 Generated with [Claude Code](https://claude.com/claude-code)