### PR TITLE
fix: shrink première colonne des tables de déclinaison/conjugaison

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -96,6 +96,7 @@ body {
 .gram-table {
   border-collapse: collapse;
   line-height: 1.35;
+  width: auto;
 }
 
 /* Compact cell padding — overrides daisyUI table defaults */
@@ -181,6 +182,7 @@ body {
   border-radius: 0.5rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
   padding: 0.25rem 0.375rem;
+  width: fit-content;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## Summary

- Ajoute `white-space: nowrap` à `.gram-table th:first-child, .gram-table td:first-child` pour que `width: 1%` force le shrink-to-fit des labels (« 1re p. », « nom. », etc.)

Closes #32