### PR TITLE
Refonte design : polices, accents CSS, header

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -35,8 +35,8 @@
 }
 
 @theme {
-  --font-body: "Times New Roman", serif;
-  --font-table: "Times New Roman", serif;
+  --font-body: "Source Sans 3", sans-serif;
+  --font-table: "Source Sans 3", sans-serif;
 
   /* Échelle typographique (ratio 1.2) */
   --text-2xs: 0.694rem;
@@ -64,15 +64,54 @@
   --shadow-grammar: 0 6px 22px rgba(0, 0, 0, 0.15);
   --shadow-grammar-pinned: 0 6px 22px rgba(28, 94, 255, 0.18);
   --shadow-bubble: 0 4px 10px rgba(0, 0, 0, 0.15);
+
+  --header-height: 3.5rem;
 }
 
 body {
-  font-family: "Times New Roman", serif;
+  font-family: "Source Sans 3", sans-serif;
   margin: 0;
   padding: 0;
   height: 100vh;
   box-sizing: border-box;
   font-size: 1.1rem;
+}
+
+/* ── App header ────────────────────────────────────────────────────── */
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: var(--color-base-200);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.app-header-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.app-header-title {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 1.2;
+  color: var(--color-base-content);
+}
+
+.app-header-o {
+  color: #2563eb;
+}
+
+.app-header-subtitle {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--color-neutral);
+  line-height: 1.2;
 }
 
 :focus-visible {
@@ -81,6 +120,7 @@ body {
 }
 
 .ukr {
+  font-family: "Playfair Display", serif;
   font-weight: bold;
   color: var(--color-ukr-blue);
   cursor: pointer;
@@ -94,8 +134,36 @@ body {
   text-decoration-color: var(--color-ukr-blue);
 }
 
+.accent,
+.with-accent {
+  position: relative;
+  display: inline-block;
+}
+
+.accent::after,
+.with-accent::after {
+  content: "\02CA"; /* modifier letter acute accent */
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 0.32em;
+  font-size: 0.75em;
+  line-height: 1;
+  pointer-events: none;
+}
+
+/* Voyelles avec point (і, ї) : accent plus haut pour éviter la collision */
+.accent[data-dot]::after,
+.with-accent[data-dot]::after {
+  top: 0.05em;
+}
+
 .accent {
   color: var(--color-accent-red);
+}
+
+.with-accent {
+  color: #2563eb;
 }
 
 .remarque {
@@ -112,10 +180,16 @@ body {
   width: auto;
 }
 
-/* Compact cell padding — overrides daisyUI table defaults */
+/* Cell padding & Ukrainian word styling */
 .gram-table th,
 .gram-table td {
-  padding: 0.375rem 0.5rem;
+  padding: 10px 12px;
+}
+
+.gram-table td {
+  font-family: "Playfair Display", serif;
+  font-size: 15px;
+  color: #1a1a1a;
 }
 
 /* First column — shrink to content (labels, case names, person) */
@@ -126,36 +200,49 @@ body {
 }
 
 .gram-table tbody tr {
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 0.5px solid #e5e5e5;
+  transition: background-color 0.15s;
 }
 
 .gram-table tbody tr:last-child {
   border-bottom: none;
 }
 
+.gram-table tbody tr:hover {
+  background-color: rgba(37, 99, 235, 0.04);
+}
+
 /* Column headers (sg., pl., m., f., etc.) */
 .gram-table thead th {
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 12px;
   font-weight: 600;
   font-style: italic;
-  color: var(--color-neutral);
-  border-bottom: 2px solid var(--color-base-300);
+  color: #6b7280;
+  border-bottom: 0.5px solid #e5e5e5;
 }
 
 /* Row labels (case names in tbody th) */
 .gram-table tbody th {
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 12px;
   font-weight: 600;
   font-style: italic;
-  color: var(--color-neutral);
+  color: #6b7280;
   text-align: left;
   white-space: nowrap;
 }
 
 /* Section divider row — tense headers, infinitif row */
 .gram-section td,
-.gram-section th {
+.gram-section th,
+.gram-table .gram-section td {
   background: var(--color-surface-raised);
-  border-top: 2px solid var(--color-base-300);
+  border-top: 0.5px solid #e5e5e5;
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 12px;
   font-weight: 700;
+  color: #6b7280;
 }
 
 /* No top border on the very first section (top of table) */
@@ -170,10 +257,13 @@ body {
 
 /* Label cell — person/gender in first column.
    No text-align: left is the default; omitting allows text-center override. */
-.gram-label {
+.gram-label,
+.gram-table td.gram-label {
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 12px;
   font-style: italic;
   font-weight: 600;
-  color: var(--color-neutral);
+  color: #6b7280;
   white-space: nowrap;
 }
 
@@ -227,11 +317,19 @@ body {
   vertical-align: top;
 }
 
+.grammar-sidebar td {
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
+}
+
 /* Section headers (case names, tense names) */
 .grammar-sidebar th {
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 12px;
   text-align: left;
   font-style: italic;
   font-weight: 700;
+  color: #6b7280;
   background: var(--color-surface-raised);
   border-top: 1.5px solid var(--color-base-300);
   position: sticky;
@@ -250,7 +348,9 @@ body {
 
 /* Label column (sg., pl., m., f., 1p., etc.) */
 .grammar-sidebar td:first-child {
-  color: var(--color-neutral);
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 12px;
+  color: #6b7280;
   white-space: nowrap;
 }
 
@@ -280,6 +380,10 @@ body {
   font-size: var(--text-sm);
   line-height: 1.25;
   pointer-events: none;
+}
+
+.hover-bubble strong {
+  font-family: "Playfair Display", serif;
 }
 
 /* Verb forms container */

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;1,400&family=Source+Sans+3:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <title>Vocabulaire ukrainien</title>
     %sveltekit.head%
   </head>

--- a/src/lib/components/AccentCheckbox.svelte
+++ b/src/lib/components/AccentCheckbox.svelte
@@ -6,9 +6,7 @@
   }
 </script>
 
-<div
-  class="fixed bottom-5 right-5 bg-base-100/90 p-2.5 rounded-md shadow-floating z-floating flex items-center gap-2"
->
+<div class="flex items-center gap-2">
   <input
     type="checkbox"
     id="accent-check"

--- a/src/lib/components/AdjectiveDetails.svelte
+++ b/src/lib/components/AdjectiveDetails.svelte
@@ -24,7 +24,7 @@
             <th>{labelCase(caseKey)}</th>
             {#each genders as gender}
               <td class="text-center">
-                <span class="text-secondary font-bold">{renderCell(forms[gender])}</span>
+                <span class="font-bold">{@html renderCell(forms[gender])}</span>
               </td>
             {/each}
           </tr>

--- a/src/lib/components/BaseDetails.svelte
+++ b/src/lib/components/BaseDetails.svelte
@@ -1,12 +1,12 @@
 <script>
-  import { addAccent } from "$lib/utils/accent.js";
+  import { addAccentHTML } from "$lib/utils/accent.js";
   import { firstPair } from "$lib/utils/parsing.js";
 
   let { details } = $props();
 
   const pair = $derived(firstPair(details.base));
-  const cell = $derived(pair ? addAccent(pair[0], pair[1]) : "");
+  const cell = $derived(pair ? addAccentHTML(pair[0], pair[1]) : "");
 </script>
 
 <h3>Forme de base</h3>
-<p><span class="text-secondary font-bold">{cell}</span></p>
+<p><span class="font-bold">{@html cell}</span></p>

--- a/src/lib/components/NounDetails.svelte
+++ b/src/lib/components/NounDetails.svelte
@@ -20,10 +20,10 @@
           <tr>
             <th>{labelCase(caseKey)}</th>
             <td class="text-center"
-              ><span class="text-secondary font-bold">{renderCell(forms.s)}</span></td
+              ><span class="font-bold">{@html renderCell(forms.s)}</span></td
             >
             <td class="text-center"
-              ><span class="text-secondary font-bold">{renderCell(forms.pl)}</span></td
+              ><span class="font-bold">{@html renderCell(forms.pl)}</span></td
             >
           </tr>
         {/each}

--- a/src/lib/components/VerbDetails.svelte
+++ b/src/lib/components/VerbDetails.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { addAccent } from "$lib/utils/accent.js";
+  import { addAccentHTML } from "$lib/utils/accent.js";
   import { toPairs, firstPair } from "$lib/utils/parsing.js";
   import { dataStore } from "$lib/stores/dataStore.svelte.js";
   import { labelTenseLabel, labelPerson } from "$lib/utils/i18n.js";
@@ -11,12 +11,12 @@
     if (!pairs.length) return "";
     return pairs
       .filter(([t]) => t)
-      .map(([t, p]) => `<span class="text-secondary font-bold">${addAccent(t, p)}</span>`)
+      .map(([t, p]) => `<span class="font-bold">${addAccentHTML(t, p)}</span>`)
       .join(", ");
   }
 
   const infPair = $derived(firstPair(details.inf));
-  const infDisplay = $derived(infPair ? addAccent(infPair[0], infPair[1]) : "");
+  const infDisplay = $derived(infPair ? addAccentHTML(infPair[0], infPair[1]) : "");
 
   const tenses = ["imp", "fut", "pres", "pass"];
 
@@ -38,7 +38,7 @@
         <tr class="gram-section">
           <td class="gram-label">Infinitif</td>
           <td colspan="2" class="text-center">
-            <span class="text-secondary font-bold">{infDisplay}</span>
+            <span class="font-bold">{@html infDisplay}</span>
           </td>
         </tr>
 

--- a/src/lib/components/WordDetails.svelte
+++ b/src/lib/components/WordDetails.svelte
@@ -2,7 +2,7 @@
   import { dataStore } from "$lib/stores/dataStore.svelte.js";
   import { uiStore } from "$lib/stores/uiStore.svelte.js";
   import { getPrincipalForm } from "$lib/utils/dataAccess.js";
-  import { addAccent } from "$lib/utils/accent.js";
+  import { addAccentHTML } from "$lib/utils/accent.js";
   import { firstPair } from "$lib/utils/parsing.js";
   import NounDetails from "./NounDetails.svelte";
   import AdjectiveDetails from "./AdjectiveDetails.svelte";
@@ -56,17 +56,17 @@
     const couplVerb = dataStore.wordData?.verb?.[details.coupl];
     if (!couplVerb?.inf) return details.coupl;
     const pair = firstPair(couplVerb.inf);
-    return pair ? addAccent(pair[0], pair[1]) : details.coupl;
+    return pair ? addAccentHTML(pair[0], pair[1]) : details.coupl;
   });
 </script>
 
 <div class="max-w-3xl mx-auto p-6 text-[1.2rem]">
   {#if details}
     <h2 class="text-xl font-semibold">
-      {displayWord}
+      {@html displayWord}
       <span class="badge badge-ghost text-xs font-normal align-middle ml-2">{displayMeta}</span
       >{#if couplDisplay}
-        <span class="text-sm font-normal ml-2">— couple asp. : {couplDisplay}</span>{/if}
+        <span class="text-sm font-normal ml-2">— couple asp. : {@html couplDisplay}</span>{/if}
     </h2>
 
     {#if uiStore.selectedCategory === "nom"}

--- a/src/lib/utils/accent.js
+++ b/src/lib/utils/accent.js
@@ -1,5 +1,6 @@
 const COMBINING_ACUTE = "\u0301";
 const UKRAINIAN_VOWELS = new Set("аеєиіїоуюя");
+const DOTTED_VOWELS = new Set("іїІЇ");
 
 /**
  * Vérifie si un caractère est une voyelle ukrainienne (аеєиіїоуюя).
@@ -33,6 +34,29 @@ export function addAccent(word, accentPosition) {
 }
 
 /**
+ * Retourne un fragment HTML où la voyelle accentuée est enveloppée dans
+ * <span class="with-accent">. L'accent est dessiné en CSS (::after).
+ * @param {string} word - Mot ukrainien
+ * @param {number} accentPosition - Position 1-based de la voyelle accentuée
+ * @returns {string} HTML avec la voyelle enveloppée
+ */
+export function addAccentHTML(word, accentPosition) {
+  if (!word) return "";
+  const chars = Array.from(word);
+  if (accentPosition > 0 && accentPosition <= chars.length) {
+    const target = chars[accentPosition - 1];
+    if (!isUkrainianVowel(target)) {
+      console.warn(
+        `addAccentHTML: position ${accentPosition} dans "${word}" pointe sur "${target}", pas une voyelle ukrainienne`,
+      );
+    }
+    const dot = DOTTED_VOWELS.has(target) ? ' data-dot' : '';
+    chars[accentPosition - 1] = `<span class="with-accent"${dot}>${target}</span>`;
+  }
+  return chars.join("");
+}
+
+/**
  * Entoure la lettre à la position donnée d'un <span> avec accent combinant.
  * Utilisé pour le rendu HTML des accents dans le DOM (via innerHTML).
  * @param {string} word - Mot ukrainien (texte brut)
@@ -42,11 +66,12 @@ export function addAccent(word, accentPosition) {
  */
 export function highlightLetter(word, position, classe) {
   if (position < 0 || position >= word.length) return word;
+  const ch = word[position];
+  const dot = DOTTED_VOWELS.has(ch) ? ' data-dot' : '';
   return (
     word.slice(0, position) +
-    `<span class="${classe}">` +
-    word[position] +
-    COMBINING_ACUTE +
+    `<span class="${classe}"${dot}>` +
+    ch +
     "</span>" +
     word.slice(position + 1)
   );

--- a/src/lib/utils/bubble.js
+++ b/src/lib/utils/bubble.js
@@ -1,6 +1,6 @@
 import { firstPair, getVariantIndex } from "./parsing.js";
 import { getLemmaEntry } from "./dataAccess.js";
-import { addAccent } from "./accent.js";
+import { addAccentHTML } from "./accent.js";
 import { labelCategory, labelTense, labelNumber } from "./i18n.js";
 import { classesToColors } from "./colors.js";
 
@@ -35,7 +35,7 @@ export function buildBubbleHTML(wd, word, category, dataInfo) {
 
   if (pair) {
     const [mot, pos] = pair;
-    const accented = addAccent(mot, pos);
+    const accented = addAccentHTML(mot, pos);
     return `<strong>${accented}</strong>${filtered.length ? " &nbsp;<em>" + filtered.join(", ") + "</em>" : ""}`;
   }
   return filtered.length ? `<em>${filtered.join(", ")}</em>` : "";

--- a/src/lib/utils/dataAccess.js
+++ b/src/lib/utils/dataAccess.js
@@ -1,4 +1,4 @@
-import { addAccent } from "./accent.js";
+import { addAccentHTML } from "./accent.js";
 import { firstPair } from "./parsing.js";
 
 /**
@@ -97,7 +97,7 @@ export function getPrincipalForm(wordData, word, category) {
   try {
     const entry = getLemmaEntry(wordData, category, word);
     const p = firstPair(entry);
-    if (p) return addAccent(p[0], p[1]);
+    if (p) return addAccentHTML(p[0], p[1]);
   } catch (err) {
     console.warn(`getPrincipalForm: erreur pour "${word}" (${category}) :`, err);
   }

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -1,5 +1,5 @@
 export { i18n, labelCategory, labelTense, labelNumber } from "./i18n.js";
-export { addAccent, highlightLetter } from "./accent.js";
+export { addAccent, addAccentHTML, highlightLetter } from "./accent.js";
 export {
   parseInfo,
   toPairs,

--- a/src/lib/utils/parsing.js
+++ b/src/lib/utils/parsing.js
@@ -1,4 +1,4 @@
-import { addAccent } from "./accent.js";
+import { addAccentHTML } from "./accent.js";
 
 /**
  * Découpe une chaîne data-info en tokens séparés par des points-virgules.
@@ -112,5 +112,5 @@ export function getVariantIndex(dataInfoTokens) {
 export function renderCellSimple(entry) {
   if (!entry) return "";
   const pair = firstPair(entry);
-  return pair ? addAccent(pair[0], pair[1]) : "";
+  return pair ? addAccentHTML(pair[0], pair[1]) : "";
 }

--- a/src/lib/utils/tableGeneration.js
+++ b/src/lib/utils/tableGeneration.js
@@ -1,4 +1,4 @@
-import { addAccent } from "./accent.js";
+import { addAccentHTML } from "./accent.js";
 import { toPairs } from "./parsing.js";
 import { labelTense, labelNumber } from "./i18n.js";
 
@@ -13,7 +13,7 @@ export function renderCell(entry) {
   if (!pairs.length) return "";
   return pairs
     .filter(([t]) => t)
-    .map(([t, p]) => addAccent(t, p))
+    .map(([t, p]) => addAccentHTML(t, p))
     .join(" / ");
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,16 @@
   });
 </script>
 
+<header class="app-header">
+  <div class="app-header-brand">
+    <span class="app-header-title">Слов<span class="app-header-o">о</span>скарб</span>
+    <span class="app-header-subtitle">Trésor lexical ukrainien</span>
+  </div>
+  <div class="mr-[60px]">
+    <AccentCheckbox />
+  </div>
+</header>
+
 {@render children()}
 
 <GrammarSidebar />
-<AccentCheckbox />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,14 +7,14 @@
   <title>Liste de mots avec fiches descriptives</title>
 </svelte:head>
 
-<div class="flex w-full h-full max-md:flex-col">
+<div class="flex w-full h-[calc(100vh-var(--header-height))] max-md:flex-col">
   <nav
-    class="w-64 shrink-0 bg-base-200 p-3 shadow-sidebar h-screen flex flex-col max-md:w-full max-md:h-auto"
+    class="w-64 shrink-0 bg-base-200 p-3 shadow-sidebar h-full flex flex-col max-md:w-full max-md:h-auto"
     aria-label="Liste de mots"
   >
     <WordList />
   </nav>
-  <main class="grow min-w-0 p-6 max-md:w-full bg-base-100">
+  <main class="grow min-w-0 p-6 max-md:w-full bg-base-100 mr-[400px] max-md:mr-0">
     <WordDetails />
   </main>
 </div>

--- a/tests/utils/accent.test.js
+++ b/tests/utils/accent.test.js
@@ -81,10 +81,9 @@ describe("addAccent vowel validation", () => {
 describe("highlightLetter", () => {
   const accent = "\u0301";
 
-  it("wraps the letter at position in a <span> with accent", () => {
+  it("wraps the letter at position in a <span> without combining accent (rendered via CSS)", () => {
     const result = highlightLetter("слово", 2, "accent");
-    expect(result).toContain('<span class="accent">');
-    expect(result).toContain(accent);
+    expect(result).toBe('сл<span class="accent">о</span>во');
   });
 
   it("returns original word when position is out of bounds", () => {
@@ -94,6 +93,6 @@ describe("highlightLetter", () => {
 
   it("correctly handles position 0 (first character)", () => {
     const result = highlightLetter("abc", 0, "hl");
-    expect(result).toBe('<span class="hl">a' + accent + "</span>bc");
+    expect(result).toBe('<span class="hl">a</span>bc');
   });
 });

--- a/tests/utils/dataAccess.test.js
+++ b/tests/utils/dataAccess.test.js
@@ -156,17 +156,17 @@ describe("getPrincipalForm", () => {
 
   it("returns accented nominative singular for nouns", () => {
     const result = getPrincipalForm(mockWordData, "слово", "nom");
-    expect(result).toBe("сло" + accent + "во");
+    expect(result).toContain('<span class="with-accent">о</span>');
   });
 
   it("returns accented nominative masculine for adjectives", () => {
     const result = getPrincipalForm(mockWordData, "великий", "adj");
-    expect(result).toContain(accent);
+    expect(result).toContain('<span class="with-accent">');
   });
 
   it("returns accented infinitive for verbs", () => {
     const result = getPrincipalForm(mockWordData, "читати", "verb");
-    expect(result).toBe("чита" + accent + "ти");
+    expect(result).toContain('<span class="with-accent">а</span>');
   });
 
   it("returns accented nominative for proper pronouns", () => {

--- a/tests/utils/parsing.test.js
+++ b/tests/utils/parsing.test.js
@@ -131,7 +131,7 @@ describe("renderCellSimple", () => {
   });
 
   it("returns accented form for a simple pair", () => {
-    expect(renderCellSimple(["слово", 3])).toBe("сло" + accent + "во");
+    expect(renderCellSimple(["слово", 3])).toContain('<span class="with-accent">о</span>');
   });
 
   it("returns unaccented form when position is -1", () => {

--- a/tests/utils/tableGeneration.test.js
+++ b/tests/utils/tableGeneration.test.js
@@ -9,7 +9,7 @@ import {
 
 describe("renderCell", () => {
   it("rend une paire simple avec accent", () => {
-    expect(renderCell(["балкон", 5])).toContain("балко");
+    expect(renderCell(["балкон", 5])).toContain('<span class="with-accent">о</span>');
   });
 
   it("retourne vide pour null", () => {


### PR DESCRIPTION
## Summary

- **Polices Google Fonts** : Playfair Display (mots ukrainiens, `.ukr`, tableaux) + Source Sans 3 (UI, labels, navigation)
- **Accents via CSS `::after`** : remplacement du combining acute U+0301 par des pseudo-éléments positionnables — indépendant de la police, ajustement spécifique pour і/ї (`data-dot`)
- **Header applicatif** « Словоскарб — Trésor lexical ukrainien » avec toggle Accents intégré
- **Tableaux redessinés** : hiérarchie typographique claire (Playfair 15px données, Source Sans 12px labels), voyelle accentuée en bleu #2563EB
- **Espace grammar sidebar réservé** (`mr-400px` permanent) pour supprimer le clignotement au hover
- **Token `--header-height`** pour découpler la hauteur du header du layout

## Fichiers modifiés (20)

- `app.css` : +130 lignes de styles (header, tableaux, accents, grammar sidebar)
- `accent.js` : nouvelle fonction `addAccentHTML` + `data-dot` sur і/ї
- 6 composants Svelte : passage `{@html}` pour le rendu des accents HTML
- 4 fichiers de tests adaptés au nouveau format

## Test plan

- [x] `npm run test` — 156/156 passent
- [ ] Vérifier visuellement les accents sur і (ex: мені) — pas de collision avec le point
- [ ] Vérifier le header sur desktop et mobile
- [ ] Vérifier que la grammar sidebar ne chevauche pas le contenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)